### PR TITLE
Add minimal Electron stream preview prototype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example configuration for OBS WebSocket port
+OBS_PORT=4455

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Stream Previewer
+
+This is a minimal prototype implementing the basic structure for a grid-based stream preview tool. It uses Electron for the desktop shell and loads stream definitions from `streams.json`.
+
+## Getting Started
+
+1. Install dependencies (requires internet access):
+
+   ```bash
+   npm install
+   ```
+
+2. Start the application:
+
+   ```bash
+   npm start
+   ```
+
+Streams are defined in `streams.json` as an array:
+
+```json
+[
+  { "title": "Sample Stream", "url": "https://example.com/stream.m3u8" }
+]
+```
+
+### OBS Connection
+
+An optional OBS WebSocket connection can be configured via the `.env` file. See `.env.example` for the available settings.
+
+The UI currently lists each stream title in a grid. Actual playback, drag/drop, hotkeys and further functionality from the requirements are left as future work.

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,23 @@
+const { app, BrowserWindow } = require('electron');
+const path = require('path');
+require('dotenv').config();
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1024,
+    height: 768,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false,
+    },
+  });
+  win.loadFile(path.join(__dirname, '../index.html'));
+}
+
+app.whenReady().then(createWindow);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Stream Previewer</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; }
+    #grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 10px; }
+    .tile { background: #333; color: #fff; padding: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Stream Previewer</h1>
+  <div id="grid"></div>
+  <script src="renderer.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tabnavigator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "electron/main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MPL-2.0",
+  "type": "commonjs"
+}

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadStreams() {
+  const filePath = path.join(__dirname, 'streams.json');
+  if (!fs.existsSync(filePath)) {
+    return [];
+  }
+  const data = fs.readFileSync(filePath, 'utf-8');
+  try {
+    return JSON.parse(data);
+  } catch (e) {
+    console.error('Failed to parse streams.json:', e);
+    return [];
+  }
+}
+
+function createTile(stream) {
+  const el = document.createElement('div');
+  el.className = 'tile';
+  el.textContent = stream.title || stream.url;
+  return el;
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  const grid = document.getElementById('grid');
+  const streams = loadStreams();
+  streams.forEach(s => grid.appendChild(createTile(s)));
+});

--- a/src/obs.js
+++ b/src/obs.js
@@ -1,0 +1,16 @@
+const OBSWebSocket = require('obs-websocket-js');
+require('dotenv').config();
+
+const obs = new OBSWebSocket();
+
+async function connect() {
+  const port = process.env.OBS_PORT || 4455;
+  try {
+    await obs.connect(`ws://localhost:${port}`);
+    console.log('Connected to OBS');
+  } catch (err) {
+    console.error('OBS connection error:', err);
+  }
+}
+
+module.exports = { connect };

--- a/streams.json
+++ b/streams.json
@@ -1,0 +1,3 @@
+[
+  {"title": "Sample Stream", "url": "https://example.com/stream.m3u8"}
+]


### PR DESCRIPTION
## Summary
- provide basic electron app skeleton
- show sample stream grid rendering
- outline OBS connection placeholder
- add README with setup steps and config notes
- include example `.env` file and `.gitignore`

## Testing
- `npm test`
- `npm install electron@latest obs-websocket-js axios dotenv` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6885c44b50bc832a8175791d66769c79